### PR TITLE
Example waits for body * instead of h1

### DIFF
--- a/src/sample-tests/steps.js
+++ b/src/sample-tests/steps.js
@@ -22,7 +22,7 @@
     this.Then(/^I should see the title "([^"]*)"$/, function (expectedTitle, callback) {
       // you can use chai-as-promised in step definitions also
       this.browser.
-        waitForVisible('h1'). // WebdriverIO chain-able promise magic
+        waitForVisible('body *'). // WebdriverIO chain-able promise magic
         getTitle().should.become(expectedTitle).and.notify(callback);
     });
 


### PR DESCRIPTION
My app doesn't have an `h1`, so I was stuck for a bit trying to decipher what this meant:

```
  Scenario:                                           # features/title.feature:11
    Given I am a new user                             # features/title.feature:12
    When I navigate to "/"                            # features/title.feature:13
    Then I should see the title "intentional failure" # features/title.feature:14
      RuntimeError: RuntimeError
           (ScriptTimeout:28) A script did not complete before its timeout expired.
```