### PR TITLE
add tag @ignore along with @dev when not in VELOCITY_CI.

### DIFF
--- a/src/mirror-server.js
+++ b/src/mirror-server.js
@@ -233,7 +233,7 @@ DEBUG = !!process.env.VELOCITY_DEBUG;
     if (process.env.CUCUMBER_TAGS) {
       args.push('--tags=' + process.env.CUCUMBER_TAGS);
     } else if (!process.env.VELOCITY_CI) {
-      args.push('--tags=@dev');
+      args.push('--tags=@dev,~@ignore');
     } else {
       args.push('--tags=~@ignore');
     }


### PR DESCRIPTION
https://github.com/xolvio/meteor-cucumber/issues/74

This issue was not resolved for me, I'm wondering what you think of this change.

In development, running my server with the simple ```meteor``` command would start the cucumber server without adding the ```~@ignore``` tag.  I had to modify the server command:

```
CUCUMBER_TAGS='~@ignore' meteor
```

This PR adds that tag in development automatically, no need for the verbose command.