### PR TITLE
Typo fixes, mostly same as for Chimp

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-[![Chimp by Xolv.io](https://raw.githubusercontent.com/xolvio/chimp/master/header.png)](http://chimpjs.com)
-
 [![Circle CI](https://circleci.com/gh/xolvio/chimp.svg?style=svg)](https://circleci.com/gh/xolvio/chimp) [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/xolvio/chimp?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
-This package allows you to do Reactive BDD in Meteor using Cucumber and Velocity. It is a wrapper of our [Chimpjs](http://chimpjs.com) npm package that has been tailored spefically for Meteor's awesome development workflow.
+This package allows you to do Reactive BDD in Meteor using [Cucumber](https://cucumber.io/docs) and [Velocity](http://velocity.meteor.com/). It is a wrapper of our [Chimpjs](http://chimpjs.com) npm package that has been tailored specifically for Meteor's awesome development workflow.
 
 ## Installation
 ```sh
@@ -12,8 +10,8 @@ meteor add xolvio:cucumber
 ## Documentation
 You can [read the full documentation here](http://chimp.readme.io/docs/meteor-cucumber) on the beautiful Readme.io.
 
-## Prerequisits
-You need to be sure you have the following installed:
+## Prerequisites
+Make sure you have the following installed:
 
 * Node & NPM
 * Java
@@ -21,7 +19,7 @@ You need to be sure you have the following installed:
 
 This package will do the rest.
 
-#Get the Book
+# Get the Book
 To learn more about testing with Meteor, consider purchasing our book [The Meteor Testing Manual](http://www.meteortesting.com/?utm_source=Cucumber&utm_medium=banner&utm_campaign=Cucumber).
 
 [![](http://www.meteortesting.com/img/tmtm.gif)](http://www.meteortesting.com/?utm_source=Cucumber&utm_medium=banner&utm_campaign=Cucumber)


### PR DESCRIPTION
Looks like this was a copy/paste from the Chimp README (or the other way around? Same typos, e.g. "Prerequisits"). Hence removing the Chimp logo.